### PR TITLE
Revert circle redeem to old name

### DIFF
--- a/src/Ethereum.sol
+++ b/src/Ethereum.sol
@@ -88,11 +88,11 @@ library Ethereum {
     /*** Blackrock BUIDL Addresses                                                                                  ***/
     /******************************************************************************************************************/
 
-    address internal constant BUIDL               = 0x7712c34205737192402172409a8F7ccef8aA2AEc;
-    address internal constant BUIDL_CIRCLE_REDEEM = 0x31D3F59Ad4aAC0eeE2247c65EBE8Bf6E9E470a53;
-    address internal constant BUIDLI              = 0x6a9DA2D710BB9B700acde7Cb81F10F1fF8C89041;
-    address internal constant BUIDLI_DEPOSIT      = 0xD1917664bE3FdAea377f6E8D5BF043ab5C3b1312;
-    address internal constant BUIDLI_REDEEM       = 0x8780Dd016171B91E4Df47075dA0a947959C34200;
+    address internal constant BUIDL          = 0x7712c34205737192402172409a8F7ccef8aA2AEc;
+    address internal constant BUIDL_REDEEM   = 0x31D3F59Ad4aAC0eeE2247c65EBE8Bf6E9E470a53;  // Circle redeem
+    address internal constant BUIDLI         = 0x6a9DA2D710BB9B700acde7Cb81F10F1fF8C89041;
+    address internal constant BUIDLI_DEPOSIT = 0xD1917664bE3FdAea377f6E8D5BF043ab5C3b1312;
+    address internal constant BUIDLI_REDEEM  = 0x8780Dd016171B91E4Df47075dA0a947959C34200;  // Offchain redeem
 
     /******************************************************************************************************************/
     /*** Centrifuge Addresses                                                                                       ***/


### PR DESCRIPTION
Use the old name because it's used in ALM Controller.