### PR TITLE
feat: Add XLayer Intents address

### DIFF
--- a/src/XLayer.sol
+++ b/src/XLayer.sol
@@ -35,6 +35,12 @@ library XLayer {
     address internal constant SPARK_VAULT_V2_IMPL   = 0xdCe929A335C75a1676EF5957A4D7a3b928C48820;  // spark-vaults-v2/SparkVault.sol@0a686ba (v1.0.1)
     address internal constant SPARK_VAULT_V2_SPUSDT = 0xc358c90D32375721Cb3924320Fdc2F8B694347Ca;  // openzeppelin-contracts/ERC1967Proxy.sol@c64a1edb (v5.4.0)
 
+    /******************************************************************************************************************/
+    /*** Spark Intents addresses                                                                                    ***/
+    /******************************************************************************************************************/
+
+    address internal constant SPARK_SAVINGS_INTENTS = 0x5bCD2f30FA1Bf675d5d6E793DAD7DdD487D21865;  // spark-savings-intents/SavingsVaultIntents.sol@d9045fc (v1.0.0)
+
     /*******************************************************************************************************************
 
     ███████╗██████╗  █████╗ ██████╗ ██╗  ██╗    ███╗   ███╗ █████╗ ███╗   ██╗ █████╗  ██████╗ ███████╗██████╗


### PR DESCRIPTION
## Conditions for PR Merge
- [ ] All contracts are verified on Etherscan or Etherscan equivalents.
- [ ] All contracts have been added to Immunefi.
- [ ] All contracts have been bytecode verified against the latest production release if authored by Spark.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing the Spark Savings Intents address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->