### PR TITLE
add: Ethereum and XLayer production PAU addresses

### DIFF
--- a/src/Ethereum.sol
+++ b/src/Ethereum.sol
@@ -20,6 +20,15 @@ library Ethereum {
     address internal constant SPK         = 0xc20059e0317DE91738d13af027DfC4a50781b066;
 
     /******************************************************************************************************************/
+    /*** Spark PAU Core addresses                                                                                   ***/
+    /******************************************************************************************************************/
+
+    address internal constant BEACON                     = 0xd47230358AB6c52A0a988150Ac4Ab888FE8B7786;  // diamond-pau/Beacon.sol@cbf71b2 (v1.14.0)
+    address internal constant PAU_FACTORY                = 0x60eB26db57bD058B6D742a1f6350A7FFeAb0681E;  // diamond-pau/PauFactory.sol@cbf71b2 (v1.14.0)
+    address internal constant ADMINISTERED_AGENT_FACTORY = 0x74C35B0990ea530926d2656003Cb3E3Bf286cA69;  // pau-administered-agent/AdministeredAgentFactory.sol@bfaaf70 (v1.0.0)
+    address internal constant DEFAULT_PAU_ASSEMBLER      = 0xb2468FCc87E3BE45Bfa521e567731375887BF8e2;  // pau-assemblers/DefaultPauAssembler.sol@d7d6f08 (v1.0.0)
+
+    /******************************************************************************************************************/
     /*** Spark Liquidity Layer addresses                                                                            ***/
     /******************************************************************************************************************/
 
@@ -37,6 +46,21 @@ library Ethereum {
     address internal constant SPARK_VAULT_V2_SPPYUSD = 0x80128DbB9f07b93DDE62A6daeadb69ED14a7D354;  // openzeppelin-contracts/ERC1967Proxy.sol@c64a1edb (v5.4.0)
     address internal constant SPARK_VAULT_V2_SPUSDC  = 0x28B3a8fb53B741A8Fd78c0fb9A6B2393d896a43d;  // openzeppelin-contracts/ERC1967Proxy.sol@c64a1edb (v5.4.0)
     address internal constant SPARK_VAULT_V2_SPUSDT  = 0xe2e7a17dFf93280dec073C995595155283e3C372;  // openzeppelin-contracts/ERC1967Proxy.sol@c64a1edb (v5.4.0)
+
+    /******************************************************************************************************************/
+    /*** Spark SPUSDC Seggregated PAU addresses                                                                     ***/
+    /******************************************************************************************************************/
+
+    address internal constant SPUSDC_PAU_ACCESS_CONTROLS = 0x36F61446638BE126a189689552f38159d30f95ef;  // diamond-pau/AccessControls.sol@cbf71b2 (v1.14.0)
+    address internal constant SPUSDC_PAU_ALM_PROXY       = 0x8D719A830b00e5571db00D173505CD56c0Ec224a;  // diamond-pau/ALMProxy.sol@cbf71b2 (v1.14.0)
+    address internal constant SPUSDC_PAU_CONTROLLER      = 0x4623cdEf0FB92499fd20f710318Cf17B8a7EB6bC;  // diamond-pau/Controller.sol@cbf71b2 (v1.14.0)
+    address internal constant SPUSDC_PAU_RATELIMITS      = 0x222712581c3631DDF938f98Dab29a6D098ec6829;  // diamond-pau/RateLimits.sol@cbf71b2 (v1.14.0)
+
+    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT         = 0xD30faA074D023af8525750561beC2Aa181562866;  // pau-administered-agent/AdministeredAgent.sol@bfaaf70 (v1.0.0)
+    // address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_ADMIN   = ; // @TODO : add admin address
+    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_ACTOR   = 0x8a25A24EDE9482C4Fc0738F99611BE58F1c839AB;
+    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_GRANTOR = 0x4B61A0E48dd1e300f64090C60F414c1aC6CbC514;
+    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_REVOKER = 0x90D8c80C028B4C09C0d8dcAab9bbB057F0513431;
 
     /******************************************************************************************************************/
     /*** Spark Intents addresses                                                                                    ***/

--- a/src/Ethereum.sol
+++ b/src/Ethereum.sol
@@ -23,10 +23,10 @@ library Ethereum {
     /*** Spark PAU Core addresses                                                                                   ***/
     /******************************************************************************************************************/
 
-    address internal constant BEACON                     = 0xd47230358AB6c52A0a988150Ac4Ab888FE8B7786;  // diamond-pau/Beacon.sol@cbf71b2 (v1.14.0)
-    address internal constant PAU_FACTORY                = 0x60eB26db57bD058B6D742a1f6350A7FFeAb0681E;  // diamond-pau/PauFactory.sol@cbf71b2 (v1.14.0)
-    address internal constant ADMINISTERED_AGENT_FACTORY = 0x74C35B0990ea530926d2656003Cb3E3Bf286cA69;  // pau-administered-agent/AdministeredAgentFactory.sol@bfaaf70 (v1.0.0)
-    address internal constant DEFAULT_PAU_ASSEMBLER      = 0xb2468FCc87E3BE45Bfa521e567731375887BF8e2;  // pau-assemblers/DefaultPauAssembler.sol@d7d6f08 (v1.0.0)
+    address internal constant SPARK_BEACON                     = 0xd47230358AB6c52A0a988150Ac4Ab888FE8B7786;  // diamond-pau/Beacon.sol@cbf71b2 (v1.14.0)
+    address internal constant SPARK_PAU_FACTORY                = 0x60eB26db57bD058B6D742a1f6350A7FFeAb0681E;  // diamond-pau/PauFactory.sol@cbf71b2 (v1.14.0)
+    address internal constant SPARK_ADMINISTERED_AGENT_FACTORY = 0x74C35B0990ea530926d2656003Cb3E3Bf286cA69;  // pau-administered-agent/AdministeredAgentFactory.sol@bfaaf70 (v1.0.0)
+    address internal constant SPARK_DEFAULT_PAU_ASSEMBLER      = 0xb2468FCc87E3BE45Bfa521e567731375887BF8e2;  // pau-assemblers/DefaultPauAssembler.sol@d7d6f08 (v1.0.0)
 
     /******************************************************************************************************************/
     /*** Spark Liquidity Layer addresses                                                                            ***/
@@ -51,16 +51,11 @@ library Ethereum {
     /*** Spark SPUSDC Seggregated PAU addresses                                                                     ***/
     /******************************************************************************************************************/
 
-    address internal constant SPUSDC_PAU_ACCESS_CONTROLS = 0x36F61446638BE126a189689552f38159d30f95ef;  // diamond-pau/AccessControls.sol@cbf71b2 (v1.14.0)
-    address internal constant SPUSDC_PAU_ALM_PROXY       = 0x8D719A830b00e5571db00D173505CD56c0Ec224a;  // diamond-pau/ALMProxy.sol@cbf71b2 (v1.14.0)
-    address internal constant SPUSDC_PAU_CONTROLLER      = 0x4623cdEf0FB92499fd20f710318Cf17B8a7EB6bC;  // diamond-pau/Controller.sol@cbf71b2 (v1.14.0)
-    address internal constant SPUSDC_PAU_RATELIMITS      = 0x222712581c3631DDF938f98Dab29a6D098ec6829;  // diamond-pau/RateLimits.sol@cbf71b2 (v1.14.0)
-
-    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT         = 0xD30faA074D023af8525750561beC2Aa181562866;  // pau-administered-agent/AdministeredAgent.sol@bfaaf70 (v1.0.0)
-    // address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_ADMIN   = ; // @TODO : add admin address
-    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_ACTOR   = 0x8a25A24EDE9482C4Fc0738F99611BE58F1c839AB;
-    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_GRANTOR = 0x4B61A0E48dd1e300f64090C60F414c1aC6CbC514;
-    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_REVOKER = 0x90D8c80C028B4C09C0d8dcAab9bbB057F0513431;
+    address internal constant SPUSDC_PAU_ACCESS_CONTROLS    = 0x36F61446638BE126a189689552f38159d30f95ef;  // diamond-pau/AccessControls.sol@cbf71b2 (v1.14.0)
+    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT = 0xD30faA074D023af8525750561beC2Aa181562866;  // pau-administered-agent/AdministeredAgent.sol@bfaaf70 (v1.0.0)
+    address internal constant SPUSDC_PAU_ALM_PROXY          = 0x8D719A830b00e5571db00D173505CD56c0Ec224a;  // diamond-pau/ALMProxy.sol@cbf71b2 (v1.14.0)
+    address internal constant SPUSDC_PAU_CONTROLLER         = 0x4623cdEf0FB92499fd20f710318Cf17B8a7EB6bC;  // diamond-pau/Controller.sol@cbf71b2 (v1.14.0)
+    address internal constant SPUSDC_PAU_RATELIMITS         = 0x222712581c3631DDF938f98Dab29a6D098ec6829;  // diamond-pau/RateLimits.sol@cbf71b2 (v1.14.0)
 
     /******************************************************************************************************************/
     /*** Spark Intents addresses                                                                                    ***/
@@ -151,6 +146,7 @@ library Ethereum {
     address internal constant ALM_RELAYER_MULTISIG              = 0x8a25A24EDE9482C4Fc0738F99611BE58F1c839AB;
     address internal constant MORPHO_CURATOR_MULTISIG           = 0x0f963A8A8c01042B69054e787E5763ABbB0646A3;
     address internal constant MORPHO_GUARDIAN_MULTISIG          = 0xf5748bBeFa17505b2F7222B23ae11584932C908B;
+    address internal constant PAU_GRANTOR_MULTISIG              = 0x4B61A0E48dd1e300f64090C60F414c1aC6CbC514;
     address internal constant SPARK_REWARDS_MULTISIG            = 0xF649956f43825d4d7295a50EDdBe1EDC814A3a83;
     address internal constant SPARKLEND_REWARDS_MULTISIG        = 0x8076807464DaC94Ac8Aa1f7aF31b58F73bD88A27;
     address internal constant SPK_BRIDGING_AND_STAKING_MULTISIG = 0x7a27a9f2A823190140cfb4027f4fBbfA438bac79;

--- a/src/XLayer.sol
+++ b/src/XLayer.sol
@@ -38,7 +38,7 @@ library XLayer {
     address internal constant LAYER_ZERO_FACET     = 0x936D542661734F2D9a96A75fF27B1BC1D2B5dfB5;  // diamond-pau/LayerZeroFacet.sol@cbf71b2 (v1.14.0)
     address internal constant SPARK_VAULT_FACET    = 0x3a35fF0B4D6375f8F3692562d378C1e5Ed482053;  // diamond-pau/SparkVaultFacet.sol@cbf71b2 (v1.14.0)
     address internal constant TRANSFER_ASSET_FACET = 0xF0830c3B800a36ff3F3E9229e0443CD5b7779e0D;  // diamond-pau/TransferAssetFacet.sol@cbf71b2 (v1.14.0)
-    // address internal constant UNISWAP_V4_FACET     = // @TODO: Deploy facet
+    address internal constant UNISWAP_V4_FACET     = 0x5d694339037c551D71825bf9B812D4350972369e;  // diamond-pau/UniswapV4Facet.sol@cbf71b2 (v1.14.0)
 
     /******************************************************************************************************************/
     /*** Spark Liquidity Layer addresses                                                                            ***/

--- a/src/XLayer.sol
+++ b/src/XLayer.sol
@@ -33,6 +33,7 @@ library XLayer {
     /******************************************************************************************************************/
 
     address internal constant SPARK_VAULT_V2_IMPL   = 0xdCe929A335C75a1676EF5957A4D7a3b928C48820;  // spark-vaults-v2/SparkVault.sol@0a686ba (v1.0.1)
+    address internal constant SPARK_VAULT_V2_SPUSDC = 0xf90E63079D97a0A1f479b2b168457F420CAFf6ba;  // openzeppelin-contracts/ERC1967Proxy.sol@c64a1edb (v5.4.0)
     address internal constant SPARK_VAULT_V2_SPUSDT = 0xc358c90D32375721Cb3924320Fdc2F8B694347Ca;  // openzeppelin-contracts/ERC1967Proxy.sol@c64a1edb (v5.4.0)
 
     /******************************************************************************************************************/
@@ -40,6 +41,23 @@ library XLayer {
     /******************************************************************************************************************/
 
     address internal constant SPARK_SAVINGS_INTENTS = 0x5bCD2f30FA1Bf675d5d6E793DAD7DdD487D21865;  // spark-savings-intents/SavingsVaultIntents.sol@d9045fc (v1.0.0)
+
+    /******************************************************************************************************************/
+    /*** Spark PAU Core addresses                                                                                   ***/
+    /******************************************************************************************************************/
+
+    address internal constant BEACON                     = 0x5612697F3F8c393A860ac0C9cf5b315c248cB0a0;  // diamond-pau/Beacon.sol@cbf71b2 (v1.14.0)
+    address internal constant PAU_FACTORY                = 0x0B33b8974eDe2985ac9E41931314337C01543fFE;  // diamond-pau/PauFactory.sol@cbf71b2 (v1.14.0)
+    address internal constant ADMINISTERED_AGENT_FACTORY = 0x039bC8CAe7A5b2B981E5ED98B840C76c7FBacDAc;  // pau-administered-agent/AdministeredAgentFactory.sol@bfaaf70 (v1.0.0)
+    address internal constant DEFAULT_PAU_ASSEMBLER      = 0xaCae58f96C959A792FaeaEc72CA870c2E36B3C80;  // pau-assemblers/DefaultPauAssembler.sol@d7d6f08 (v1.0.0)
+
+    /******************************************************************************************************************/
+    /*** Spark PAU Facets addresses                                                                                 ***/
+    /******************************************************************************************************************/
+
+    address internal constant CCTP_FACET           = 0x4a966353B421dF6ddd08E432A1E55B884Cb92D4E;  // diamond-pau/CCTPFacet.sol@cbf71b2 (v1.14.0)
+    address internal constant SPARK_VAULT_FACET    = 0x3a35fF0B4D6375f8F3692562d378C1e5Ed482053;  // diamond-pau/SparkVaultFacet.sol@cbf71b2 (v1.14.0)
+    address internal constant TRANSFER_ASSET_FACET = 0xF0830c3B800a36ff3F3E9229e0443CD5b7779e0D;  // diamond-pau/TransferAssetFacet.sol@cbf71b2 (v1.14.0)
 
     /*******************************************************************************************************************
 

--- a/src/XLayer.sol
+++ b/src/XLayer.sol
@@ -61,12 +61,12 @@ library XLayer {
     /*** Spark SPUSDC Seggregated PAU addresses                                                                     ***/
     /******************************************************************************************************************/
 
-    address internal constant SPUSDC_PAU_ACCESS_CONTROLS = 0x30271Ae5d90B34f0f8BAA840AaE63a7DBF347e84;
-    address internal constant SPUSDC_PAU_ALM_PROXY       = 0xe6D5d041Fc5e7fDD0A53C13e78a1cc7e4ffCb667;
-    address internal constant SPUSDC_PAU_CONTROLLER      = 0x8d19d306cA6075f74B26B150383379aedB0250f6;
-    address internal constant SPUSDC_PAU_RATELIMITS      = 0xBC3Ea763532aA0dec71449414b85ca66c6dD63e2;
+    address internal constant SPUSDC_PAU_ACCESS_CONTROLS = 0x30271Ae5d90B34f0f8BAA840AaE63a7DBF347e84;  // diamond-pau/AccessControls.sol@cbf71b2 (v1.14.0)
+    address internal constant SPUSDC_PAU_ALM_PROXY       = 0xe6D5d041Fc5e7fDD0A53C13e78a1cc7e4ffCb667;  // diamond-pau/ALMProxy.sol@cbf71b2 (v1.14.0)
+    address internal constant SPUSDC_PAU_CONTROLLER      = 0x8d19d306cA6075f74B26B150383379aedB0250f6;  // diamond-pau/Controller.sol@cbf71b2 (v1.14.0)
+    address internal constant SPUSDC_PAU_RATELIMITS      = 0xBC3Ea763532aA0dec71449414b85ca66c6dD63e2;  // diamond-pau/RateLimits.sol@cbf71b2 (v1.14.0)
 
-    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT         = 0x79b4055Eda153f739B5EA63C9B647c1a095059f5;
+    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT         = 0x79b4055Eda153f739B5EA63C9B647c1a095059f5;  // pau-administered-agent/AdministeredAgent.sol@bfaaf70 (v1.0.0)
     // address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_ADMIN   = ; // @TODO : add admin address
     address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_ACTOR   = 0x8a25A24EDE9482C4Fc0738F99611BE58F1c839AB;
     address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_GRANTOR = 0x4B61A0E48dd1e300f64090C60F414c1aC6CbC514;

--- a/src/XLayer.sol
+++ b/src/XLayer.sol
@@ -20,6 +20,27 @@ library XLayer {
     address internal constant SPARK_RECEIVER = 0x4bd50B9c00Ae19e8B59723F27645C7A5cCe7a4A0;  // xchain-helpers/OptimismReceiver.sol@1e362bf (v1.2.0)
 
     /******************************************************************************************************************/
+    /*** Spark PAU Core addresses                                                                                   ***/
+    /******************************************************************************************************************/
+
+    address internal constant BEACON                     = 0x5612697F3F8c393A860ac0C9cf5b315c248cB0a0;  // diamond-pau/Beacon.sol@cbf71b2 (v1.14.0)
+    address internal constant PAU_FACTORY                = 0x0B33b8974eDe2985ac9E41931314337C01543fFE;  // diamond-pau/PauFactory.sol@cbf71b2 (v1.14.0)
+    address internal constant ADMINISTERED_AGENT_FACTORY = 0x039bC8CAe7A5b2B981E5ED98B840C76c7FBacDAc;  // pau-administered-agent/AdministeredAgentFactory.sol@bfaaf70 (v1.0.0)
+    address internal constant DEFAULT_PAU_ASSEMBLER      = 0xaCae58f96C959A792FaeaEc72CA870c2E36B3C80;  // pau-assemblers/DefaultPauAssembler.sol@d7d6f08 (v1.0.0)
+
+    /******************************************************************************************************************/
+    /*** Spark PAU Facets addresses                                                                                 ***/
+    /******************************************************************************************************************/
+
+    address internal constant AAVE_FACET           = 0xc8C8930F28622D240fF380bC8b2224119b477249;  // diamond-pau/AAVEFacet.sol@cbf71b2 (v1.14.0)
+    address internal constant CCTP_FACET           = 0x4a966353B421dF6ddd08E432A1E55B884Cb92D4E;  // diamond-pau/CCTPFacet.sol@cbf71b2 (v1.14.0)
+    address internal constant ERC4626_FACET        = 0x3fC45da74c30644172620520F6bAf6783aec11F2;  // diamond-pau/ERC4626Facet.sol@cbf71b2 (v1.14.0)
+    address internal constant LAYER_ZERO_FACET     = 0x936D542661734F2D9a96A75fF27B1BC1D2B5dfB5;  // diamond-pau/LayerZeroFacet.sol@cbf71b2 (v1.14.0)
+    address internal constant SPARK_VAULT_FACET    = 0x3a35fF0B4D6375f8F3692562d378C1e5Ed482053;  // diamond-pau/SparkVaultFacet.sol@cbf71b2 (v1.14.0)
+    address internal constant TRANSFER_ASSET_FACET = 0xF0830c3B800a36ff3F3E9229e0443CD5b7779e0D;  // diamond-pau/TransferAssetFacet.sol@cbf71b2 (v1.14.0)
+    // address internal constant UNISWAP_V4_FACET     = // @TODO: Deploy facet
+
+    /******************************************************************************************************************/
     /*** Spark Liquidity Layer addresses                                                                            ***/
     /******************************************************************************************************************/
 
@@ -37,27 +58,25 @@ library XLayer {
     address internal constant SPARK_VAULT_V2_SPUSDT = 0xc358c90D32375721Cb3924320Fdc2F8B694347Ca;  // openzeppelin-contracts/ERC1967Proxy.sol@c64a1edb (v5.4.0)
 
     /******************************************************************************************************************/
+    /*** Spark SPUSDC Seggregated PAU addresses                                                                     ***/
+    /******************************************************************************************************************/
+
+    address internal constant SPUSDC_PAU_ACCESS_CONTROLS = 0x30271Ae5d90B34f0f8BAA840AaE63a7DBF347e84;
+    address internal constant SPUSDC_PAU_ALM_PROXY       = 0xe6D5d041Fc5e7fDD0A53C13e78a1cc7e4ffCb667;
+    address internal constant SPUSDC_PAU_CONTROLLER      = 0x8d19d306cA6075f74B26B150383379aedB0250f6;
+    address internal constant SPUSDC_PAU_RATELIMITS      = 0xBC3Ea763532aA0dec71449414b85ca66c6dD63e2;
+
+    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT         = 0x79b4055Eda153f739B5EA63C9B647c1a095059f5;
+    // address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_ADMIN   = ; // @TODO : add admin address
+    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_ACTOR   = 0x8a25A24EDE9482C4Fc0738F99611BE58F1c839AB;
+    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_GRANTOR = 0x4B61A0E48dd1e300f64090C60F414c1aC6CbC514;
+    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_REVOKER = 0x90D8c80C028B4C09C0d8dcAab9bbB057F0513431;
+
+    /******************************************************************************************************************/
     /*** Spark Intents addresses                                                                                    ***/
     /******************************************************************************************************************/
 
     address internal constant SPARK_SAVINGS_INTENTS = 0x5bCD2f30FA1Bf675d5d6E793DAD7DdD487D21865;  // spark-savings-intents/SavingsVaultIntents.sol@d9045fc (v1.0.0)
-
-    /******************************************************************************************************************/
-    /*** Spark PAU Core addresses                                                                                   ***/
-    /******************************************************************************************************************/
-
-    address internal constant BEACON                     = 0x5612697F3F8c393A860ac0C9cf5b315c248cB0a0;  // diamond-pau/Beacon.sol@cbf71b2 (v1.14.0)
-    address internal constant PAU_FACTORY                = 0x0B33b8974eDe2985ac9E41931314337C01543fFE;  // diamond-pau/PauFactory.sol@cbf71b2 (v1.14.0)
-    address internal constant ADMINISTERED_AGENT_FACTORY = 0x039bC8CAe7A5b2B981E5ED98B840C76c7FBacDAc;  // pau-administered-agent/AdministeredAgentFactory.sol@bfaaf70 (v1.0.0)
-    address internal constant DEFAULT_PAU_ASSEMBLER      = 0xaCae58f96C959A792FaeaEc72CA870c2E36B3C80;  // pau-assemblers/DefaultPauAssembler.sol@d7d6f08 (v1.0.0)
-
-    /******************************************************************************************************************/
-    /*** Spark PAU Facets addresses                                                                                 ***/
-    /******************************************************************************************************************/
-
-    address internal constant CCTP_FACET           = 0x4a966353B421dF6ddd08E432A1E55B884Cb92D4E;  // diamond-pau/CCTPFacet.sol@cbf71b2 (v1.14.0)
-    address internal constant SPARK_VAULT_FACET    = 0x3a35fF0B4D6375f8F3692562d378C1e5Ed482053;  // diamond-pau/SparkVaultFacet.sol@cbf71b2 (v1.14.0)
-    address internal constant TRANSFER_ASSET_FACET = 0xF0830c3B800a36ff3F3E9229e0443CD5b7779e0D;  // diamond-pau/TransferAssetFacet.sol@cbf71b2 (v1.14.0)
 
     /*******************************************************************************************************************
 

--- a/src/XLayer.sol
+++ b/src/XLayer.sol
@@ -23,10 +23,10 @@ library XLayer {
     /*** Spark PAU Core addresses                                                                                   ***/
     /******************************************************************************************************************/
 
-    address internal constant BEACON                     = 0x5612697F3F8c393A860ac0C9cf5b315c248cB0a0;  // diamond-pau/Beacon.sol@cbf71b2 (v1.14.0)
-    address internal constant PAU_FACTORY                = 0x0B33b8974eDe2985ac9E41931314337C01543fFE;  // diamond-pau/PauFactory.sol@cbf71b2 (v1.14.0)
-    address internal constant ADMINISTERED_AGENT_FACTORY = 0x039bC8CAe7A5b2B981E5ED98B840C76c7FBacDAc;  // pau-administered-agent/AdministeredAgentFactory.sol@bfaaf70 (v1.0.0)
-    address internal constant DEFAULT_PAU_ASSEMBLER      = 0xaCae58f96C959A792FaeaEc72CA870c2E36B3C80;  // pau-assemblers/DefaultPauAssembler.sol@d7d6f08 (v1.0.0)
+    address internal constant SPARK_BEACON                     = 0x5612697F3F8c393A860ac0C9cf5b315c248cB0a0;  // diamond-pau/Beacon.sol@cbf71b2 (v1.14.0)
+    address internal constant SPARK_PAU_FACTORY                = 0x0B33b8974eDe2985ac9E41931314337C01543fFE;  // diamond-pau/PauFactory.sol@cbf71b2 (v1.14.0)
+    address internal constant SPARK_ADMINISTERED_AGENT_FACTORY = 0x039bC8CAe7A5b2B981E5ED98B840C76c7FBacDAc;  // pau-administered-agent/AdministeredAgentFactory.sol@bfaaf70 (v1.0.0)
+    address internal constant SPARK_DEFAULT_PAU_ASSEMBLER      = 0xaCae58f96C959A792FaeaEc72CA870c2E36B3C80;  // pau-assemblers/DefaultPauAssembler.sol@d7d6f08 (v1.0.0)
 
     /******************************************************************************************************************/
     /*** Spark PAU Facets addresses                                                                                 ***/
@@ -61,16 +61,11 @@ library XLayer {
     /*** Spark SPUSDC Seggregated PAU addresses                                                                     ***/
     /******************************************************************************************************************/
 
-    address internal constant SPUSDC_PAU_ACCESS_CONTROLS = 0x30271Ae5d90B34f0f8BAA840AaE63a7DBF347e84;  // diamond-pau/AccessControls.sol@cbf71b2 (v1.14.0)
-    address internal constant SPUSDC_PAU_ALM_PROXY       = 0xe6D5d041Fc5e7fDD0A53C13e78a1cc7e4ffCb667;  // diamond-pau/ALMProxy.sol@cbf71b2 (v1.14.0)
-    address internal constant SPUSDC_PAU_CONTROLLER      = 0x8d19d306cA6075f74B26B150383379aedB0250f6;  // diamond-pau/Controller.sol@cbf71b2 (v1.14.0)
-    address internal constant SPUSDC_PAU_RATELIMITS      = 0xBC3Ea763532aA0dec71449414b85ca66c6dD63e2;  // diamond-pau/RateLimits.sol@cbf71b2 (v1.14.0)
-
-    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT         = 0x79b4055Eda153f739B5EA63C9B647c1a095059f5;  // pau-administered-agent/AdministeredAgent.sol@bfaaf70 (v1.0.0)
-    // address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_ADMIN   = ; // @TODO : add admin address
-    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_ACTOR   = 0x8a25A24EDE9482C4Fc0738F99611BE58F1c839AB;
-    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_GRANTOR = 0x4B61A0E48dd1e300f64090C60F414c1aC6CbC514;
-    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT_REVOKER = 0x90D8c80C028B4C09C0d8dcAab9bbB057F0513431;
+    address internal constant SPUSDC_PAU_ACCESS_CONTROLS    = 0x30271Ae5d90B34f0f8BAA840AaE63a7DBF347e84;  // diamond-pau/AccessControls.sol@cbf71b2 (v1.14.0)
+    address internal constant SPUSDC_PAU_ADMINISTERED_AGENT = 0x79b4055Eda153f739B5EA63C9B647c1a095059f5;  // pau-administered-agent/AdministeredAgent.sol@bfaaf70 (v1.0.0)
+    address internal constant SPUSDC_PAU_ALM_PROXY          = 0xe6D5d041Fc5e7fDD0A53C13e78a1cc7e4ffCb667;  // diamond-pau/ALMProxy.sol@cbf71b2 (v1.14.0)
+    address internal constant SPUSDC_PAU_CONTROLLER         = 0x8d19d306cA6075f74B26B150383379aedB0250f6;  // diamond-pau/Controller.sol@cbf71b2 (v1.14.0)
+    address internal constant SPUSDC_PAU_RATELIMITS         = 0xBC3Ea763532aA0dec71449414b85ca66c6dD63e2;  // diamond-pau/RateLimits.sol@cbf71b2 (v1.14.0)
 
     /******************************************************************************************************************/
     /*** Spark Intents addresses                                                                                    ***/
@@ -91,9 +86,13 @@ library XLayer {
     /*** Multisig addresses                                                                                         ***/
     /******************************************************************************************************************/
 
+    // Operational Multisigs
+    address internal constant ALM_RELAYER_MULTISIG = 0x8a25A24EDE9482C4Fc0738F99611BE58F1c839AB;
+    address internal constant PAU_GRANTOR_MULTISIG = 0x4B61A0E48dd1e300f64090C60F414c1aC6CbC514;
+
+    // Emergency Multisigs
     address internal constant ALM_BACKSTOP_RELAYER_MULTISIG = 0x9330edE0Fc6E3E0D47Ebf3C145efd569796aC7F5;
     address internal constant ALM_FREEZER_MULTISIG          = 0x90D8c80C028B4C09C0d8dcAab9bbB057F0513431;
-    address internal constant ALM_RELAYER_MULTISIG          = 0x8a25A24EDE9482C4Fc0738F99611BE58F1c839AB;
 
     /*******************************************************************************************************************
 


### PR DESCRIPTION
## Conditions for PR Merge
- [ ] All contracts are verified on Etherscan or Etherscan equivalents.
- [ ] All contracts have been added to Immunefi.
- [ ] All contracts have been bytecode verified against the latest production release if authored by Spark.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized Spark PAU configuration naming across supported networks.
  * Reorganized SPUSDC PAU configuration entries for improved consistency.
  * Added the deployed Uniswap V4 facet address.
  * Clarified operational and emergency multisig classifications while preserving emergency multisig entries.
  * Removed separate administered-agent role-holder and placeholder configuration entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->